### PR TITLE
10: responsive dialog

### DIFF
--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -1,6 +1,4 @@
 import { Suspense } from "react";
-import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
-import { getQueryClient, trpc } from "@/trpc/server";
 import { ErrorBoundary } from "react-error-boundary";
 
 import {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -131,3 +131,10 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    @apply cursor-pointer;
+  }
+}

--- a/src/components/responsive-diaglog.tsx
+++ b/src/components/responsive-diaglog.tsx
@@ -1,0 +1,60 @@
+import { useIsMobile } from "@/hooks/use-mobile";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+
+interface ResponsiveDialogProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const ResponsiveDialog = ({
+  title,
+  description,
+  children,
+  open,
+  onOpenChange,
+}: ResponsiveDialogProps) => {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent className="sm:max-w-lg">
+          <DrawerHeader>
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
+          <div className="p-4">{children}</div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,17 +1,25 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Command as CommandPrimitive } from "cmdk"
-import { SearchIcon } from "lucide-react"
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-mobile";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog"
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
 
 function Command({
   className,
@@ -26,7 +34,7 @@ function Command({
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CommandDialog({
@@ -37,10 +45,10 @@ function CommandDialog({
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof Dialog> & {
-  title?: string
-  description?: string
-  className?: string
-  showCloseButton?: boolean
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
 }) {
   return (
     <Dialog {...props}>
@@ -57,7 +65,56 @@ function CommandDialog({
         </Command>
       </DialogContent>
     </Dialog>
-  )
+  );
+}
+
+function CommandResponsiveDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
+}) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <Drawer {...props}>
+        <DrawerContent className="overflow-hidden p-0">
+          <DrawerHeader className="sr-only">
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
+          <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+            {children}
+          </Command>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 function CommandInput({
@@ -79,7 +136,7 @@ function CommandInput({
         {...props}
       />
     </div>
-  )
+  );
 }
 
 function CommandList({
@@ -95,7 +152,7 @@ function CommandList({
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CommandEmpty({
@@ -107,7 +164,7 @@ function CommandEmpty({
       className="py-6 text-center text-sm"
       {...props}
     />
-  )
+  );
 }
 
 function CommandGroup({
@@ -123,7 +180,7 @@ function CommandGroup({
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CommandSeparator({
@@ -136,7 +193,7 @@ function CommandSeparator({
       className={cn("bg-border -mx-1 h-px", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CommandItem({
@@ -152,7 +209,7 @@ function CommandItem({
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CommandShortcut({
@@ -168,11 +225,12 @@ function CommandShortcut({
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
   Command,
+  CommandResponsiveDialog,
   CommandDialog,
   CommandInput,
   CommandList,
@@ -181,4 +239,4 @@ export {
   CommandItem,
   CommandShortcut,
   CommandSeparator,
-}
+};

--- a/src/modules/agents/server/procedures.ts
+++ b/src/modules/agents/server/procedures.ts
@@ -10,10 +10,6 @@ export const agentsRouter = createTRPCRouter({
     const data = await db
         .select()
         .from(agents);
-
-        //await new Promise((resolve) => setTimeout(resolve, 5000));
-        // throw new TRPCError({ code:"BAD_REQUEST"});
-
     return data;
   }),
 });

--- a/src/modules/agents/ui/views/agents-view.tsx
+++ b/src/modules/agents/ui/views/agents-view.tsx
@@ -2,14 +2,26 @@
 
 import { ErrorState } from "@/components/error-state";
 import { LoadingState } from "@/components/loading-state";
+import { ResponsiveDialog } from "@/components/responsive-diaglog";
 import { useTRPC } from "@/trpc/client";
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 
 export const AgentsView = () => {
   const trpc = useTRPC();
   const { data } = useSuspenseQuery(trpc.agents.getMany.queryOptions());
 
-  return <pre>{JSON.stringify(data, null, 2)}</pre>;
+  return (
+    <div>
+      <ResponsiveDialog
+        title="Responsive test"
+        description="Responsive description"
+        open={true}
+        onOpenChange={() => {}}
+      >
+        <pre>{JSON.stringify(data, null, 2)}</pre>;
+      </ResponsiveDialog>
+    </div>
+  );
 };
 
 export const AgentsViewLoading = () => {

--- a/src/modules/dashboard/ui/components/dashboard-command.tsx
+++ b/src/modules/dashboard/ui/components/dashboard-command.tsx
@@ -3,6 +3,7 @@ import {
   CommandDialog,
   CommandList,
   CommandItem,
+  CommandResponsiveDialog,
 } from "@/components/ui/command";
 import { SetStateAction, Dispatch } from "react";
 
@@ -13,11 +14,11 @@ interface Props {
 
 export const DashboardCommand = ({ open, setOpen }: Props) => {
   return (
-    <CommandDialog open={open} onOpenChange={setOpen}>
+    <CommandResponsiveDialog open={open} onOpenChange={setOpen}>
       <CommandInput placeholder="Find a meeting or agent" />
       <CommandList>
         <CommandItem>Test</CommandItem>
       </CommandList>
-    </CommandDialog>
+    </CommandResponsiveDialog>
   );
 };


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add responsive dialog component for mobile/desktop adaptation

- Implement responsive command dialog functionality

- Clean up debug code and unused imports

- Add cursor pointer styling for interactive elements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ResponsiveDialog"] --> B["Mobile Detection"]
  B --> C["Drawer on Mobile"]
  B --> D["Dialog on Desktop"]
  E["CommandResponsiveDialog"] --> F["Enhanced Command UI"]
  A --> G["Agents View Integration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>responsive-diaglog.tsx</strong><dd><code>New responsive dialog component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/responsive-diaglog.tsx

<ul><li>Create new responsive dialog component<br> <li> Use mobile hook to switch between Dialog and Drawer<br> <li> Support title, description, and children props<br> <li> Handle open state and change callbacks</ul>


</details>


  </td>
  <td><a href="https://github.com/vismark-cupla/meetai/pull/9/files#diff-f5745655157b5041c669f08776d3ea78d774e1814450314eed7731009741f3a0">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>command.tsx</strong><dd><code>Add responsive command dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/ui/command.tsx

<ul><li>Add CommandResponsiveDialog function<br> <li> Import drawer components and mobile hook<br> <li> Switch between Dialog and Drawer based on screen size<br> <li> Fix semicolon formatting throughout file</ul>


</details>


  </td>
  <td><a href="https://github.com/vismark-cupla/meetai/pull/9/files#diff-26f79b7285e9229b24786d7669d904180992d6b26ab9780a28b43146a87a2669">+78/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agents-view.tsx</strong><dd><code>Integrate responsive dialog in agents view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/agents/ui/views/agents-view.tsx

<ul><li>Import and use ResponsiveDialog component<br> <li> Remove unused useQuery import<br> <li> Wrap data display in responsive dialog<br> <li> Add test dialog with hardcoded open state</ul>


</details>


  </td>
  <td><a href="https://github.com/vismark-cupla/meetai/pull/9/files#diff-478546d28443440cf9f7b5cb5001f101f991bf0c340a470f99c402c47bd94870">+14/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboard-command.tsx</strong><dd><code>Use responsive command dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/dashboard/ui/components/dashboard-command.tsx

<ul><li>Replace CommandDialog with CommandResponsiveDialog<br> <li> Import new responsive command component<br> <li> Maintain same props and functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/vismark-cupla/meetai/pull/9/files#diff-3c8c71448011abdafd883f4c1d71e4d2c02d0d6b2cb09194a8e95ba8c0118780">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>globals.css</strong><dd><code>Add button cursor styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/globals.css

<ul><li>Add cursor pointer styling for buttons<br> <li> Apply to enabled buttons and role="button" elements<br> <li> Use Tailwind apply directive</ul>


</details>


  </td>
  <td><a href="https://github.com/vismark-cupla/meetai/pull/9/files#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>procedures.ts</strong><dd><code>Remove debug code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/agents/server/procedures.ts

<ul><li>Remove commented debug code<br> <li> Clean up setTimeout and TRPCError lines<br> <li> Maintain core functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/vismark-cupla/meetai/pull/9/files#diff-1f6f283869399c9effc1b7d17b62b743281d7a2f1c2dcad776e843e0962557bd">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Remove unused imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(dashboard)/agents/page.tsx

<ul><li>Remove unused imports<br> <li> Clean up dehydrate, HydrationBoundary, getQueryClient, trpc imports</ul>


</details>


  </td>
  <td><a href="https://github.com/vismark-cupla/meetai/pull/9/files#diff-971e46f7647fecb3e22a5ba2b5e86ee51d0e96c91ec20aa1ae1c2be6ea276abf">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

